### PR TITLE
Escape README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip install cv
 ```
 
 ## Module Example
-With a <module> present on PyPI and `<module>.py` in current directory:
+With a \<module\> present on PyPI and `<module>.py` in current directory:
 ```python
 __version__ = '7.7.7'
 
@@ -33,7 +33,7 @@ Simply run:
 cv <module>
 ```
 
-If `7.7.7` version of <module> is on PyPI already you’ll get a `VersionExists` error:
+If `7.7.7` version of \<module\> is on PyPI already you’ll get a `VersionExists` error:
 ```plain
 Traceback (most recent call last):
   File "./cv", line 86, in <module>

--- a/cv.py
+++ b/cv.py
@@ -8,7 +8,7 @@ Finishes with an VersionExists exception and a non-zero exit code if the version
 """
 from __future__ import annotations
 
-__version__ = '1.0.0.dev7'
+__version__ = '1.0.0.dev8'
 
 import os
 import sys


### PR DESCRIPTION
Unescaped `<module>` string is considered an html tag by markdown.